### PR TITLE
Use Liquity's LUSD in place of ARTH.

### DIFF
--- a/packages/contracts/contracts/BorrowerOperations.sol
+++ b/packages/contracts/contracts/BorrowerOperations.sol
@@ -15,7 +15,6 @@ import "./Dependencies/console.sol";
 import "./Interfaces/IGovernance.sol";
 import "./Interfaces/ILiquityLUSDToken.sol";
 import "./Interfaces/IController.sol";
-import "./Interfaces/IGasPool.sol";
 import "./Dependencies/ISimpleERCFund.sol";
 
 contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOperations {

--- a/packages/contracts/contracts/BorrowerOperations.sol
+++ b/packages/contracts/contracts/BorrowerOperations.sol
@@ -27,7 +27,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
 
     address stabilityPoolAddress;
 
-    IGasPool public gasPool;
+    address gasPoolAddress;
 
     ICollSurplusPool collSurplusPool;
 
@@ -74,7 +74,6 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         IActivePool activePool;
         ILiquityLUSDToken lusdToken;
         IPriceFeed priceFeed;
-        IGasPool gasPool;
     }
 
     enum BorrowerOperation {
@@ -138,7 +137,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         activePool = IActivePool(_activePoolAddress);
         defaultPool = IDefaultPool(_defaultPoolAddress);
         stabilityPoolAddress = _stabilityPoolAddress;
-        gasPool = IGasPool(_gasPoolAddress);
+        gasPoolAddress = _gasPoolAddress;
         collSurplusPool = ICollSurplusPool(_collSurplusPoolAddress);
         sortedTroves = ISortedTroves(_sortedTrovesAddress);
         lusdToken = ILiquityLUSDToken(_lusdTokenAddress);
@@ -183,8 +182,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
             troveManager,
             activePool,
             lusdToken,
-            getPriceFeed(),
-            gasPool
+            getPriceFeed()
         );
         LocalVariables_openTrove memory vars;
 
@@ -256,7 +254,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         _withdrawLUSD(
             contractsCache.activePool,
             contractsCache.lusdToken,
-            address(gasPool),
+            gasPoolAddress,
             LUSD_GAS_COMPENSATION,
             LUSD_GAS_COMPENSATION
         );
@@ -361,8 +359,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
             troveManager,
             activePool,
             lusdToken,
-            getPriceFeed(),
-            gasPool
+            getPriceFeed()
         );
         LocalVariables_adjustTrove memory vars;
 
@@ -499,7 +496,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
 
         // Burn the repaid LUSD from the user's balance and the gas compensation from the Gas Pool
         _repayLUSD(activePoolCached, lusdTokenCached, msg.sender, debt.sub(LUSD_GAS_COMPENSATION));
-        _repayLUSD(activePoolCached, lusdTokenCached, address(gasPool), LUSD_GAS_COMPENSATION);
+        _repayLUSD(activePoolCached, lusdTokenCached, gasPoolAddress, LUSD_GAS_COMPENSATION);
 
         // Send the collateral back to the user
         activePoolCached.sendETH(msg.sender, coll);

--- a/packages/contracts/contracts/GasPool.sol
+++ b/packages/contracts/contracts/GasPool.sol
@@ -2,11 +2,6 @@
 
 pragma solidity 0.6.11;
 
-import "./Dependencies/Ownable.sol";
-import "./Dependencies/CheckContract.sol";
-import "./Interfaces/IGasPool.sol";
-import "./Interfaces/IController.sol";
-import "./Dependencies/IERC20.sol";
 
 /**
  * The purpose of this contract is to hold LUSD tokens for gas compensation:
@@ -18,68 +13,6 @@ import "./Dependencies/IERC20.sol";
  * 50 LUSD debt on the trove is cancelled.
  * See this issue for more context: https://github.com/liquity/dev/issues/186
  */
-contract GasPool is Ownable, CheckContract, IGasPool {
-    string public constant NAME = "Gas pool";
-
-    IERC20 public lusdToken;
-    IController public coreController;
-
-    address public troveManager;
-    address public borrowerOperationsAddress;
-
-    event LUSDAddressChanged(address _lusdAddress);
-    event TroveManagerAddressChanged(address _troveManagerAddress);
-    event CoreControllerAddressChanged(address _coreControllerAddress);
-    event BorrowerOperationsAddressChanged(address _borrowerOperationsAddress);
-    event ReturnToLiquidator(address indexed to, uint256 amount, uint256 timestamp);
-    event LUSDBurnt(uint256 amount, uint256 timestamp);
-
-    function setAddresses(
-        address _troveManagerAddress,
-        address _lusdTokenAddress,
-        address _borrowerOperationsAddress,
-        address _coreControllerAddress
-    ) external override onlyOwner {
-        checkContract(_lusdTokenAddress);
-        checkContract(_troveManagerAddress);
-        checkContract(_borrowerOperationsAddress);
-        checkContract(_coreControllerAddress);
-
-        lusdToken = IERC20(_lusdTokenAddress);
-        troveManager = _troveManagerAddress;
-        borrowerOperationsAddress = _borrowerOperationsAddress;
-        coreController = IController(_coreControllerAddress);
-
-        emit CoreControllerAddressChanged(_coreControllerAddress);
-        emit BorrowerOperationsAddressChanged(_borrowerOperationsAddress);
-        emit LUSDAddressChanged(_lusdTokenAddress);
-        emit TroveManagerAddressChanged(_troveManagerAddress);
-
-        _renounceOwnership();
-    }
-
-    function burnLUSD(uint256 _amount) external override {
-        _requireCallerIsTroveMOrBO();
-        emit LUSDBurnt(_amount, block.timestamp);
-
-        lusdToken.approve(address(coreController), _amount);
-        coreController.burn(address(this), _amount);
-    }
-
-    function returnToLiquidator(address _account, uint256 amount) external override {
-        _requireCallerIsTroveM();
-        emit ReturnToLiquidator(_account, amount, block.timestamp);
-        lusdToken.transfer(_account, amount);
-    }
-
-    function _requireCallerIsTroveM() internal view {
-        require(msg.sender == troveManager, "GasPool: Caller is not trove manager");
-    }
-
-    function _requireCallerIsTroveMOrBO() internal view {
-        require(
-            msg.sender == troveManager || msg.sender == borrowerOperationsAddress,
-            "GasPool: Caller is not trove manager nor borrower operations"
-        );
-    }
+contract GasPool {
+    // do nothing, as the core contracts have permission to send to and burn from this address
 }

--- a/packages/contracts/contracts/Interfaces/IBorrowerOperations.sol
+++ b/packages/contracts/contracts/Interfaces/IBorrowerOperations.sol
@@ -6,7 +6,6 @@ pragma solidity 0.6.11;
 interface IBorrowerOperations {
     // --- Events ---
 
-    event CoreControllerAddressChanged(address _coreControllerAddress);
     event GovernanceAddressChanged(address _governanceAddress);
     event TroveManagerAddressChanged(address _newTroveManagerAddress);
     event ActivePoolAddressChanged(address _activePoolAddress);
@@ -40,8 +39,7 @@ interface IBorrowerOperations {
         address _sortedTrovesAddress,
         address _lusdTokenAddress,
         address _wethAddress,
-        address _governanceAddress,
-        address _coreControllerAddress
+        address _governanceAddress
     ) external;
 
     function registerFrontEnd() external;

--- a/packages/contracts/contracts/Interfaces/IGasPool.sol
+++ b/packages/contracts/contracts/Interfaces/IGasPool.sol
@@ -2,17 +2,24 @@
 
 pragma solidity 0.6.11;
 
+import "./IPool.sol";
 
-/**
- * The purpose of this contract is to hold LUSD tokens for gas compensation:
- * https://github.com/liquity/dev#gas-compensation
- * When a borrower opens a trove, an additional 50 LUSD debt is issued,
- * and 50 LUSD is minted and sent to this contract.
- * When a borrower closes their active trove, this gas compensation is refunded:
- * 50 LUSD is burned from the this contract's balance, and the corresponding
- * 50 LUSD debt on the trove is cancelled.
- * See this issue for more context: https://github.com/liquity/dev/issues/186
- */
-contract GasPool {
-    // do nothing, as the core contracts have permission to send to and burn from this address
+interface IGasPool {
+    // --- Events ---
+    event LUSDAddressChanged(address _lusdAddress);
+    event TroveManagerAddressChanged(address _troveManagerAddress);
+    event ReturnToLiquidator(address indexed to, uint256 amount, uint256 timestamp);
+    event CoreControllerAddressChanged(address _coreControllerAddress);
+    event BorrowerOperationsAddressChanged(address _borrowerOperationsAddress);
+    event LUSDBurnt(uint256 amount, uint256 timestamp);
+    
+    // --- Functions ---
+    function setAddresses(
+        address _troveManagerAddress, 
+        address _lusdTokenAddress, 
+        address _borrowerOperationAddress, 
+        address _coreControllerAddress
+    ) external;
+    function returnToLiquidator(address _account, uint256 amount) external;
+    function burnLUSD(uint256 _amount) external;
 }

--- a/packages/contracts/contracts/Interfaces/IGasPool.sol
+++ b/packages/contracts/contracts/Interfaces/IGasPool.sol
@@ -2,24 +2,17 @@
 
 pragma solidity 0.6.11;
 
-import "./IPool.sol";
 
-interface IGasPool {
-    // --- Events ---
-    event LUSDAddressChanged(address _lusdAddress);
-    event TroveManagerAddressChanged(address _troveManagerAddress);
-    event ReturnToLiquidator(address indexed to, uint256 amount, uint256 timestamp);
-    event CoreControllerAddressChanged(address _coreControllerAddress);
-    event BorrowerOperationsAddressChanged(address _borrowerOperationsAddress);
-    event LUSDBurnt(uint256 amount, uint256 timestamp);
-    
-    // --- Functions ---
-    function setAddresses(
-        address _troveManagerAddress, 
-        address _lusdTokenAddress, 
-        address _borrowerOperationAddress, 
-        address _coreControllerAddress
-    ) external;
-    function returnToLiquidator(address _account, uint256 amount) external;
-    function burnLUSD(uint256 _amount) external;
+/**
+ * The purpose of this contract is to hold LUSD tokens for gas compensation:
+ * https://github.com/liquity/dev#gas-compensation
+ * When a borrower opens a trove, an additional 50 LUSD debt is issued,
+ * and 50 LUSD is minted and sent to this contract.
+ * When a borrower closes their active trove, this gas compensation is refunded:
+ * 50 LUSD is burned from the this contract's balance, and the corresponding
+ * 50 LUSD debt on the trove is cancelled.
+ * See this issue for more context: https://github.com/liquity/dev/issues/186
+ */
+contract GasPool {
+    // do nothing, as the core contracts have permission to send to and burn from this address
 }

--- a/packages/contracts/contracts/Interfaces/ILiquityLUSDToken.sol
+++ b/packages/contracts/contracts/Interfaces/ILiquityLUSDToken.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+import "../Dependencies/IERC20.sol";
+import "../Dependencies/IERC2612.sol";
+
+interface ILiquityLUSDToken is IERC20, IERC2612 { 
+    
+    // --- Events ---
+
+    event TroveManagerAddressChanged(address _troveManagerAddress);
+    event StabilityPoolAddressChanged(address _newStabilityPoolAddress);
+    event BorrowerOperationsAddressChanged(address _newBorrowerOperationsAddress);
+
+    event LUSDTokenBalanceUpdated(address _user, uint _amount);
+
+    // --- Functions ---
+
+    function mint(address _account, uint256 _amount) external;
+
+    function burn(address _account, uint256 _amount) external;
+
+    function sendToPool(address _sender,  address poolAddress, uint256 _amount) external;
+
+    function returnFromPool(address poolAddress, address user, uint256 _amount ) external;
+}

--- a/packages/contracts/contracts/Interfaces/ILiquityLUSDToken.sol
+++ b/packages/contracts/contracts/Interfaces/ILiquityLUSDToken.sol
@@ -9,13 +9,19 @@ interface ILiquityLUSDToken is IERC20, IERC2612 {
     
     // --- Events ---
 
-    event TroveManagerAddressChanged(address _troveManagerAddress);
-    event StabilityPoolAddressChanged(address _newStabilityPoolAddress);
-    event BorrowerOperationsAddressChanged(address _newBorrowerOperationsAddress);
+    event BorrowerOperationsAddressToggled(address borrowerOperations, bool oldFlag, bool newFlag, uint256 timestamp);
+    event TroveManagerToggled(address troveManager, bool oldFlag, bool newFlag, uint256 timestamp);
+    event StabilityPoolToggled(address stabilityPool, bool oldFlag, bool newFlag, uint256 timestamp);
 
     event LUSDTokenBalanceUpdated(address _user, uint _amount);
 
     // --- Functions ---
+
+    function toggleBorrowerOperations(address borrowerOperations) external;
+
+    function toggleTroveManager(address troveManager) external;
+
+    function toggleStabilityPool(address stabilityPool) external;
 
     function mint(address _account, uint256 _amount) external;
 

--- a/packages/contracts/contracts/Interfaces/IStabilityPool.sol
+++ b/packages/contracts/contracts/Interfaces/IStabilityPool.sol
@@ -84,8 +84,7 @@ interface IStabilityPool {
         address _sortedTrovesAddress,
         address _communityIssuanceAddress,
         address _wethAddress,
-        address _governanceAddress,
-        address _coreControllerAddress
+        address _governanceAddress
     ) external;
 
     /*

--- a/packages/contracts/contracts/Interfaces/ITroveManager.sol
+++ b/packages/contracts/contracts/Interfaces/ITroveManager.sol
@@ -4,14 +4,13 @@ pragma solidity 0.6.11;
 
 import "./IStabilityPool.sol";
 import "./ILiquityBase.sol";
-import "../Interfaces/ILUSDToken.sol";
+import "../Interfaces/ILiquityLUSDToken.sol";
 
 // Common interface for the Trove Manager.
 interface ITroveManager is ILiquityBase {
     // --- Events ---
 
     event StabilityFeeCharged(uint256 LUSDAmount, uint256 feeAmount, uint256 timestamp);
-    event CoreControllerChanged(address _coreControllerAddress);
     event BorrowerOperationsAddressChanged(address _newBorrowerOperationsAddress);
     event LUSDTokenAddressChanged(address _newLUSDTokenAddress);
     event ActivePoolAddressChanged(address _activePoolAddress);
@@ -22,7 +21,6 @@ interface ITroveManager is ILiquityBase {
     event SortedTrovesAddressChanged(address _sortedTrovesAddress);
     event WETHAddressChanged(address _wethAddressChanged);
     event GovernanceAddressChanged(address _governanceAddress);
-    event CoreControllerAddressChanged(address _coreControllerAddress);
 
     event TroveOwnerDetailsUpdated(
         address owner,
@@ -80,13 +78,12 @@ interface ITroveManager is ILiquityBase {
         address _lusdTokenAddress,
         address _sortedTrovesAddress,
         address _governanceAddress,
-        address _coreControllerAddress,
         address _wethAddress
     ) external;
 
     function stabilityPool() external view returns (IStabilityPool);
 
-    function lusdToken() external view returns (ILUSDToken);
+    function lusdToken() external view returns (ILiquityLUSDToken);
 
     function getTroveOwnersCount() external view returns (uint256);
 

--- a/packages/contracts/contracts/LiquityLUSDToken.sol
+++ b/packages/contracts/contracts/LiquityLUSDToken.sol
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+import "./Interfaces/ILiquityLUSDToken.sol";
+import "./Dependencies/SafeMath.sol";
+import "./Dependencies/CheckContract.sol";
+import "./Dependencies/console.sol";
+/*
+*
+* Based upon OpenZeppelin's ERC20 contract:
+* https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol
+*  
+* and their EIP2612 (ERC20Permit / ERC712) functionality:
+* https://github.com/OpenZeppelin/openzeppelin-contracts/blob/53516bc555a454862470e7860a9b5254db4d00f5/contracts/token/ERC20/ERC20Permit.sol
+* 
+*
+* --- Functionality added specific to the LUSDToken ---
+* 
+* 1) Transfer protection: blacklist of addresses that are invalid recipients (i.e. core Liquity contracts) in external 
+* transfer() and transferFrom() calls. The purpose is to protect users from losing tokens by mistakenly sending LUSD directly to a Liquity 
+* core contract, when they should rather call the right function. 
+*
+* 2) sendToPool() and returnFromPool(): functions callable only Liquity core contracts, which move LUSD tokens between Liquity <-> user.
+*/
+
+contract LiquityLUSDToken is CheckContract, ILiquityLUSDToken {
+    using SafeMath for uint256;
+    
+    uint256 private _totalSupply;
+    string constant internal _NAME = "ARTH Valuecoin";
+    string constant internal _SYMBOL = "ARTH";
+    string constant internal _VERSION = "2";
+    uint8 constant internal _DECIMALS = 18;
+    
+    // --- Data for EIP2612 ---
+    
+    // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 private constant _PERMIT_TYPEHASH = 0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+    // keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 private constant _TYPE_HASH = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
+
+    // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to
+    // invalidate the cached domain separator if the chain id changes.
+    bytes32 private immutable _CACHED_DOMAIN_SEPARATOR;
+    uint256 private immutable _CACHED_CHAIN_ID;
+
+    bytes32 private immutable _HASHED_NAME;
+    bytes32 private immutable _HASHED_VERSION;
+    
+    mapping (address => uint256) private _nonces;
+    
+    // User data for LUSD token
+    mapping (address => uint256) private _balances;
+    mapping (address => mapping (address => uint256)) private _allowances;  
+    
+    // --- Addresses ---
+    address public immutable troveManagerAddress;
+    address public immutable stabilityPoolAddress;
+    address public immutable borrowerOperationsAddress;
+    
+    // --- Events ---
+    event TroveManagerAddressChanged(address _troveManagerAddress);
+    event StabilityPoolAddressChanged(address _newStabilityPoolAddress);
+    event BorrowerOperationsAddressChanged(address _newBorrowerOperationsAddress);
+
+    constructor
+    ( 
+        address _troveManagerAddress,
+        address _stabilityPoolAddress,
+        address _borrowerOperationsAddress
+    ) 
+        public 
+    {  
+        checkContract(_troveManagerAddress);
+        checkContract(_stabilityPoolAddress);
+        checkContract(_borrowerOperationsAddress);
+
+        troveManagerAddress = _troveManagerAddress;
+        emit TroveManagerAddressChanged(_troveManagerAddress);
+
+        stabilityPoolAddress = _stabilityPoolAddress;
+        emit StabilityPoolAddressChanged(_stabilityPoolAddress);
+
+        borrowerOperationsAddress = _borrowerOperationsAddress;        
+        emit BorrowerOperationsAddressChanged(_borrowerOperationsAddress);
+        
+        bytes32 hashedName = keccak256(bytes(_NAME));
+        bytes32 hashedVersion = keccak256(bytes(_VERSION));
+        
+        _HASHED_NAME = hashedName;
+        _HASHED_VERSION = hashedVersion;
+        _CACHED_CHAIN_ID = _chainID();
+        _CACHED_DOMAIN_SEPARATOR = _buildDomainSeparator(_TYPE_HASH, hashedName, hashedVersion);
+    }
+
+    // --- Functions for intra-Liquity calls ---
+
+    function mint(address _account, uint256 _amount) external override {
+        _requireCallerIsBorrowerOperations();
+        _mint(_account, _amount);
+    }
+
+    function burn(address _account, uint256 _amount) external override {
+        _requireCallerIsBOorTroveMorSP();
+        _burn(_account, _amount);
+    }
+
+    function sendToPool(address _sender,  address _poolAddress, uint256 _amount) external override {
+        _requireCallerIsStabilityPool();
+        _transfer(_sender, _poolAddress, _amount);
+    }
+
+    function returnFromPool(address _poolAddress, address _receiver, uint256 _amount) external override {
+        _requireCallerIsTroveMorSP();
+        _transfer(_poolAddress, _receiver, _amount);
+    }
+
+    // --- External functions ---
+
+    function totalSupply() external view override returns (uint256) {
+        return _totalSupply;
+    }
+
+    function balanceOf(address account) external view override returns (uint256) {
+        return _balances[account];
+    }
+
+    function transfer(address recipient, uint256 amount) external override returns (bool) {
+        _requireValidRecipient(recipient);
+        _transfer(msg.sender, recipient, amount);
+        return true;
+    }
+
+    function allowance(address owner, address spender) external view override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    function approve(address spender, uint256 amount) external override returns (bool) {
+        _approve(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transferFrom(address sender, address recipient, uint256 amount) external override returns (bool) {
+        _requireValidRecipient(recipient);
+        _transfer(sender, recipient, amount);
+        _approve(sender, msg.sender, _allowances[sender][msg.sender].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    function increaseAllowance(address spender, uint256 addedValue) external override returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].add(addedValue));
+        return true;
+    }
+
+    function decreaseAllowance(address spender, uint256 subtractedValue) external override returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    // --- EIP 2612 Functionality ---
+
+    function domainSeparator() public view override returns (bytes32) {    
+        if (_chainID() == _CACHED_CHAIN_ID) {
+            return _CACHED_DOMAIN_SEPARATOR;
+        } else {
+            return _buildDomainSeparator(_TYPE_HASH, _HASHED_NAME, _HASHED_VERSION);
+        }
+    }
+
+    function permit
+    (
+        address owner, 
+        address spender, 
+        uint amount, 
+        uint deadline, 
+        uint8 v, 
+        bytes32 r, 
+        bytes32 s
+    ) 
+        external 
+        override 
+    {            
+        require(deadline >= now, 'LUSD: expired deadline');
+        bytes32 digest = keccak256(abi.encodePacked('\x19\x01', 
+                         domainSeparator(), keccak256(abi.encode(
+                         _PERMIT_TYPEHASH, owner, spender, amount, 
+                         _nonces[owner]++, deadline))));
+        address recoveredAddress = ecrecover(digest, v, r, s);
+        require(recoveredAddress == owner, 'LUSD: invalid signature');
+        _approve(owner, spender, amount);
+    }
+
+    function nonces(address owner) external view override returns (uint256) { // FOR EIP 2612
+        return _nonces[owner];
+    }
+
+    // --- Internal operations ---
+
+    function _chainID() private pure returns (uint256 chainID) {
+        assembly {
+            chainID := chainid()
+        }
+    }
+    
+    function _buildDomainSeparator(bytes32 typeHash, bytes32 name, bytes32 version) private view returns (bytes32) {
+        return keccak256(abi.encode(typeHash, name, version, _chainID(), address(this)));
+    }
+
+    // --- Internal operations ---
+    // Warning: sanity checks (for sender and recipient) should have been done before calling these internal functions
+
+    function _transfer(address sender, address recipient, uint256 amount) internal {
+        assert(sender != address(0));
+        assert(recipient != address(0));
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    function _mint(address account, uint256 amount) internal {
+        assert(account != address(0));
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    function _burn(address account, uint256 amount) internal {
+        assert(account != address(0));
+        
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    function _approve(address owner, address spender, uint256 amount) internal {
+        assert(owner != address(0));
+        assert(spender != address(0));
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    // --- 'require' functions ---
+
+    function _requireValidRecipient(address _recipient) internal view {
+        require(
+            _recipient != address(0) && 
+            _recipient != address(this),
+            "LUSD: Cannot transfer tokens directly to the LUSD token contract or the zero address"
+        );
+        require(
+            _recipient != stabilityPoolAddress && 
+            _recipient != troveManagerAddress && 
+            _recipient != borrowerOperationsAddress, 
+            "LUSD: Cannot transfer tokens directly to the StabilityPool, TroveManager or BorrowerOps"
+        );
+    }
+
+    function _requireCallerIsBorrowerOperations() internal view {
+        require(msg.sender == borrowerOperationsAddress, "LUSDToken: Caller is not BorrowerOperations");
+    }
+
+    function _requireCallerIsBOorTroveMorSP() internal view {
+        require(
+            msg.sender == borrowerOperationsAddress ||
+            msg.sender == troveManagerAddress ||
+            msg.sender == stabilityPoolAddress,
+            "LUSD: Caller is neither BorrowerOperations nor TroveManager nor StabilityPool"
+        );
+    }
+
+    function _requireCallerIsStabilityPool() internal view {
+        require(msg.sender == stabilityPoolAddress, "LUSD: Caller is not the StabilityPool");
+    }
+
+    function _requireCallerIsTroveMorSP() internal view {
+        require(
+            msg.sender == troveManagerAddress || msg.sender == stabilityPoolAddress,
+            "LUSD: Caller is neither TroveManager nor StabilityPool");
+    }
+
+    // --- Optional functions ---
+
+    function name() external view override returns (string memory) {
+        return _NAME;
+    }
+
+    function symbol() external view override returns (string memory) {
+        return _SYMBOL;
+    }
+
+    function decimals() external view override returns (uint8) {
+        return _DECIMALS;
+    }
+
+    function version() external view override returns (string memory) {
+        return _VERSION;
+    }
+
+    function permitTypeHash() external view override returns (bytes32) {
+        return _PERMIT_TYPEHASH;
+    }
+}

--- a/packages/contracts/contracts/StabilityPool.sol
+++ b/packages/contracts/contracts/StabilityPool.sol
@@ -15,8 +15,7 @@ import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
 import "./Dependencies/console.sol";
 import "./Interfaces/IGovernance.sol";
-import "./Interfaces/IController.sol";
-import "./Interfaces/ILUSDToken.sol";
+import "./Interfaces/ILiquityLUSDToken.sol";
 
 /*
  * The Stability Pool holds LUSD tokens deposited by Stability Pool depositors.
@@ -156,9 +155,7 @@ contract StabilityPool is LiquityBase, Ownable, CheckContract, IStabilityPool {
 
     ITroveManager public troveManager;
 
-    ILUSDToken public lusdToken;
-    
-    IController public coreController;
+    ILiquityLUSDToken public lusdToken;
 
     // Needed to check if there are pending liquidations
     ISortedTroves public sortedTroves;
@@ -243,7 +240,6 @@ contract StabilityPool is LiquityBase, Ownable, CheckContract, IStabilityPool {
 
     event StabilityPoolETHBalanceUpdated(uint256 _newBalance);
     event StabilityPoolLUSDBalanceUpdated(uint256 _newBalance);
-    event CoreControllerAddressChanged(address _newCoreControllerAddress);
     event BorrowerOperationsAddressChanged(address _newBorrowerOperationsAddress);
     event TroveManagerAddressChanged(address _newTroveManagerAddress);
     event ActivePoolAddressChanged(address _newActivePoolAddress);
@@ -286,8 +282,7 @@ contract StabilityPool is LiquityBase, Ownable, CheckContract, IStabilityPool {
         address _sortedTrovesAddress,
         address _communityIssuanceAddress,
         address _wethAddress,
-        address _governanceAddress,
-        address _coreControllerAddress
+        address _governanceAddress
     ) external override onlyOwner {
         checkContract(_borrowerOperationsAddress);
         checkContract(_troveManagerAddress);
@@ -297,17 +292,15 @@ contract StabilityPool is LiquityBase, Ownable, CheckContract, IStabilityPool {
         checkContract(_communityIssuanceAddress);
         checkContract(_wethAddress);
         checkContract(_governanceAddress);
-        checkContract(_coreControllerAddress);
 
         borrowerOperations = IBorrowerOperations(_borrowerOperationsAddress);
         troveManager = ITroveManager(_troveManagerAddress);
         activePool = IActivePool(_activePoolAddress);
-        lusdToken = ILUSDToken(_lusdTokenAddress);
+        lusdToken = ILiquityLUSDToken(_lusdTokenAddress);
         sortedTroves = ISortedTroves(_sortedTrovesAddress);
         communityIssuance = ICommunityIssuance(_communityIssuanceAddress);
         weth = IERC20(_wethAddress);
         governance = IGovernance(_governanceAddress);
-        coreController = IController(_coreControllerAddress);
 
         emit BorrowerOperationsAddressChanged(_borrowerOperationsAddress);
         emit TroveManagerAddressChanged(_troveManagerAddress);
@@ -316,7 +309,6 @@ contract StabilityPool is LiquityBase, Ownable, CheckContract, IStabilityPool {
         emit SortedTrovesAddressChanged(_sortedTrovesAddress);
         emit CommunityIssuanceAddressChanged(_communityIssuanceAddress);
         emit GovernanceAddressChanged(_governanceAddress);
-        emit CoreControllerAddressChanged(_coreControllerAddress);
 
         _renounceOwnership();
     }
@@ -660,9 +652,7 @@ contract StabilityPool is LiquityBase, Ownable, CheckContract, IStabilityPool {
         activePoolCached.decreaseLUSDDebt(_debtToOffset);
         _decreaseLUSD(_debtToOffset);
 
-        // Burn the debt that was successfully offset
-        lusdToken.approve(address(coreController), _debtToOffset);
-        coreController.burn(address(this), _debtToOffset);
+        lusdToken.burn(address(this), _debtToOffset);
 
         activePoolCached.sendETH(address(this), _collToAdd);
     }
@@ -890,7 +880,7 @@ contract StabilityPool is LiquityBase, Ownable, CheckContract, IStabilityPool {
 
     // Transfer the LUSD tokens from the user to the Stability Pool's address, and update its recorded LUSD
     function _sendLUSDtoStabilityPool(address _address, uint256 _amount) internal {
-        coreController.sendToPool(_address, address(this), _amount);  // _address must approve coreController to send arth to this contract.
+        lusdToken.sendToPool(_address, address(this), _amount);
         uint256 newTotalLUSDDeposits = totalLUSDDeposits.add(_amount);
         totalLUSDDeposits = newTotalLUSDDeposits;
         emit StabilityPoolLUSDBalanceUpdated(newTotalLUSDDeposits);
@@ -914,9 +904,7 @@ contract StabilityPool is LiquityBase, Ownable, CheckContract, IStabilityPool {
             return;
         }
 
-        // Rather than just doing a transfer from coreController, transfer the amount from here itself.
-        // Since this contract itself has balance and is the sender.
-        lusdToken.transfer(_depositor, LUSDWithdrawal);
+        lusdToken.returnFromPool(address(this), _depositor, LUSDWithdrawal);
         _decreaseLUSD(LUSDWithdrawal);
     }
 

--- a/packages/contracts/contracts/TestContracts/EchidnaTester.sol
+++ b/packages/contracts/contracts/TestContracts/EchidnaTester.sol
@@ -91,7 +91,6 @@ contract EchidnaTester {
             address(lusdToken),
             address(sortedTroves),
             address(governance),
-            address(controller),
             address(weth)
         );
 

--- a/packages/contracts/contracts/TestContracts/EchidnaTester.sol
+++ b/packages/contracts/contracts/TestContracts/EchidnaTester.sol
@@ -127,8 +127,7 @@ contract EchidnaTester {
             address(sortedTroves),
             address(0),
             address(weth),
-            address(governance),
-            address(controller)
+            address(governance)
         );
 
         collSurplusPool.setAddresses(

--- a/packages/contracts/contracts/TestContracts/EchidnaTester.sol
+++ b/packages/contracts/contracts/TestContracts/EchidnaTester.sol
@@ -74,12 +74,12 @@ contract EchidnaTester {
 
         sortedTroves = new SortedTroves();
 
-        gasPool.setAddresses(
-            address(troveManager),
-            address(lusdToken),
-            address(borrowerOperations),
-            address(controller)
-        );
+        //   gasPool.setAddresses(
+        //    address(troveManager),
+        //    address(lusdToken),
+        //    address(borrowerOperations),
+        //    address(controller)
+        // );
 
         troveManager.setAddresses(
             address(borrowerOperations),

--- a/packages/contracts/contracts/TestContracts/EchidnaTester.sol
+++ b/packages/contracts/contracts/TestContracts/EchidnaTester.sol
@@ -105,8 +105,7 @@ contract EchidnaTester {
             address(sortedTroves),
             address(lusdToken),
             address(weth),
-            address(governance),
-            address(controller)
+            address(governance)
         );
 
         activePool.setAddresses(

--- a/packages/contracts/contracts/TroveManager.sol
+++ b/packages/contracts/contracts/TroveManager.sol
@@ -10,7 +10,6 @@ import "./Dependencies/LiquityBase.sol";
 import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
 import "./Interfaces/IGovernance.sol";
-import "./Interfaces/IGasPool.sol";
 import "./Interfaces/ILiquityLUSDToken.sol";
 
 contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
@@ -21,7 +20,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
     address public wethAddress;
     
     IStabilityPool public override stabilityPool;
-    IGasPool gasPool;
+    address gasPoolAddress;
     ICollSurplusPool collSurplusPool;
     ILiquityLUSDToken public override lusdToken;
 
@@ -169,7 +168,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         ILiquityLUSDToken lusdToken;
         ISortedTroves sortedTroves;
         ICollSurplusPool collSurplusPool;
-        IGasPool gasPool;
+        address gasPoolAddress;
         IPriceFeed priceFeed;
         IGovernance governance;
     }
@@ -277,7 +276,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         activePool = IActivePool(_activePoolAddress);
         defaultPool = IDefaultPool(_defaultPoolAddress);
         stabilityPool = IStabilityPool(_stabilityPoolAddress);
-        gasPool = IGasPool(_gasPoolAddress);
+        gasPoolAddress = _gasPoolAddress;
         collSurplusPool = ICollSurplusPool(_collSurplusPoolAddress);
         lusdToken = ILiquityLUSDToken(_lusdTokenAddress);
         sortedTroves = ISortedTroves(_sortedTrovesAddress);
@@ -574,7 +573,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
             ILiquityLUSDToken(address(0)),
             sortedTroves,
             ICollSurplusPool(address(0)),
-            IGasPool(address(0)),
+            address(0),
             getPriceFeed(),
             governance
         );
@@ -1003,8 +1002,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         uint256 _ETH
     ) internal {
         if (_LUSD > 0) {
-            gasPool.returnToLiquidator(_liquidator, _LUSD);
-            // lusdToken.returnFromPool(gasPoolAddress, _liquidator, _LUSD);
+            lusdToken.returnFromPool(gasPoolAddress, _liquidator, _LUSD);
         }
 
         if (_ETH > 0) {
@@ -1105,7 +1103,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         uint256 _LUSD,
         uint256 _ETH
     ) internal {
-        _contractsCache.gasPool.burnLUSD(_LUSD);
+        _contractsCache.lusdToken.burn(gasPoolAddress, _LUSD);
         // Update Active Pool LUSD, and send ETH to account
         _contractsCache.activePool.decreaseLUSDDebt(_LUSD);
 
@@ -1167,7 +1165,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
             lusdToken,
             sortedTroves,
             collSurplusPool,
-            gasPool,
+            gasPoolAddress,
             getPriceFeed(),
             governance
         );

--- a/packages/contracts/hardhat.config.js
+++ b/packages/contracts/hardhat.config.js
@@ -88,6 +88,13 @@ module.exports = {
                 getSecret('ACCOUNT2_PRIVATEKEY', '0x3ec7cedbafd0cb9ec05bf9f7ccfa1e8b42b3e3a02c75addfccbfeb328d1b383b')
             ]
           },
+        bscTestnet: {
+            url: 'https://data-seed-prebsc-1-s1.binance.org:8545/',
+            accounts: [
+                getSecret('DEPLOYER_PRIVATEKEY', '0x60ddfe7f579ab6867cbe7a2dc03853dc141d7a4ab6dbefc0dae2d2b1bd4e487f'),
+                getSecret('ACCOUNT2_PRIVATEKEY', '0x3ec7cedbafd0cb9ec05bf9f7ccfa1e8b42b3e3a02c75addfccbfeb328d1b383b')
+            ]
+        },
         mainnet: {
             url: alchemyUrl(),
             gasPrice: 150000000000,

--- a/packages/contracts/mainnetDeployment/bscTestnetDeployment.js
+++ b/packages/contracts/mainnetDeployment/bscTestnetDeployment.js
@@ -1,0 +1,34 @@
+const configParams = require("./params/bscTestnet.js")
+const MainnetDeploymentHelper = require("../utils/testnetDeploymentHelpers.js")
+
+async function main() {
+    const date = new Date();
+    const gasPrice = configParams.GAS_PRICE;
+
+    console.log('Deployment start time', date.toUTCString());
+    console.log('Gas price', gasPrice.toString());
+
+    const deployerWallet = (await ethers.getSigners())[0];
+
+    const mdh = new MainnetDeploymentHelper(configParams, deployerWallet);
+    await mdh.loadAllContractFactories();
+    const deploymentState = mdh.loadPreviousDeployment();
+
+    console.log(`Deployer address: ${deployerWallet.address}`);
+    assert.equal(deployerWallet.address, configParams.DEPLOYER_ADDRS.DEPLOYER);
+    let deployerETHBalance = await ethers.provider.getBalance(deployerWallet.address);
+    console.log(`Deployer ETH balance before: ${deployerETHBalance}`);
+
+    // Deploy core logic contracts.
+    await mdh.deploy(deploymentState);
+
+    deployerETHBalance = await ethers.provider.getBalance(deployerWallet.address);
+    console.log(`Deployer's ETH balance after deployments: ${deployerETHBalance}`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/packages/contracts/mainnetDeployment/params/bscTestnet.js
+++ b/packages/contracts/mainnetDeployment/params/bscTestnet.js
@@ -1,0 +1,41 @@
+const EXTERNAL_ADDRS  = {
+    DAI: '',
+    WETH: '',
+    ARTH: '',
+    GMU_ORACLE: '',
+    WMATIC: "",
+    CHAINLINK_WMATIC_USD: "",
+    CHAINLINK_DAI_USD: "",
+    CHAINLINK_WETH_USD: "",
+    MahaToken: '',
+    MAHA_ARTH_PAIR_ORACLE: '',
+    ECOSYSTEMFUND: '',  // TODO: add this addr.
+};
+
+const DEPLOYER_ADDRS = {
+    DEPLOYER: "0xbA1af27c0eFdfBE8B0FE1E8F890f9E896D1B2d6f",  // TODO; change this addr
+    TIMELOCK: "0xbA1af27c0eFdfBE8B0FE1E8F890f9E896D1B2d6f" // TODO; change this addr
+};
+
+const delay = ms => new Promise(res => setTimeout(res, ms));
+const waitFunction = async () => delay(90000); // Wait 90s.
+
+const TX_CONFIRMATIONS = 1;
+const GAS_PRICE = 50 * 1000000000; // 5.1 gwei
+const NETWORK_NAME = 'bscTestnet';
+const COLLATERLAS = ['BUSD', 'WBNB'];
+const OUTPUT_FILE = './output/bscTestnet.json';
+const ETHERSCAN_BASE_URL = 'https://testnet.bscscan.com/address';
+
+module.exports = {
+    COLLATERLAS,
+    EXTERNAL_ADDRS,
+    DEPLOYER_ADDRS,
+    ...DEPLOYER_ADDRS,
+    OUTPUT_FILE,
+    waitFunction,
+    GAS_PRICE,
+    TX_CONFIRMATIONS,
+    ETHERSCAN_BASE_URL,
+    NETWORK_NAME
+};

--- a/packages/contracts/utils/testnetDeploymentHelpers.js
+++ b/packages/contracts/utils/testnetDeploymentHelpers.js
@@ -1,0 +1,572 @@
+const fs = require('fs')
+const { BigNumber } = require('ethers')
+const { network, ethers } = require('hardhat');
+
+const maxBytes32 = '0x' + 'f'.repeat(64)
+const ZERO_ADDRESS = '0x' + '0'.repeat(40)
+
+class MainnetDeploymentHelper {
+  constructor(configParams, deployerWallet) {
+    this.deployments = {}
+    this.hre = require("hardhat")
+    this.configParams = configParams
+    this.deployerWallet = deployerWallet
+  }
+
+  async loadAllContractFactories() {
+    this.mockPairOracle = await this.getFactory("MockUniswapOracle");
+    this.mockTokenFactory = await this.getFactory("ERC20Mock")
+    this.gasPoolFactory = await this.getFactory("GasPool")
+    this.unipoolFactory = await this.getFactory("Unipool")
+    this.lusdTokenFactory = await this.getFactory("LiquityLUSDToken")
+    this.mahaTokenFactory = await this.getFactory("MockMaha")
+    this.priceFeedFactory = await this.getFactory("PriceFeedTestnet")
+    this.lqtyTokenFactory = await this.getFactory("LQTYToken")
+    this.activePoolFactory = await this.getFactory("ActivePool")
+    this.governanceFactory = await this.getFactory('Governance')
+    this.lqtyStakingFactory = await this.getFactory('LQTYStaking')
+    this.defaultPoolFactory = await this.getFactory("DefaultPool")
+    this.hintHelpersFactory = await this.getFactory("HintHelpers")
+    this.sortedTrovesFactory = await this.getFactory("SortedTroves")
+    this.troveManagerFactory = await this.getFactory("TroveManager")
+    this.ecosystemFundFactory = await this.getFactory("EcosystemFund")
+    this.stabilityPoolFactory = await this.getFactory("StabilityPool")
+    this.collSurplusPoolFactory = await this.getFactory("CollSurplusPool")
+    this.multiTroveGetterFactory = await this.getFactory("MultiTroveGetter")
+    this.communityIssuanceFactory = await this.getFactory("CommunityIssuance")
+    this.borrowerOperationsFactory = await this.getFactory("BorrowerOperations")
+    this.lockupContractFactoryFactory = await this.getFactory('LockupContractFactory')
+  }
+
+  isMainnet() {
+    return this.configParams.NETWORK_NAME == 'mainnet' ||
+        this.configParams.NETWORK_NAME == 'matic' ||
+        this.configParams.NETWORK_NAME == 'bsc' ||
+        network.name == 'matic' ||
+        network.name == 'mainnet' ||
+        network.name == 'bsc'
+  }
+
+  loadPreviousDeployment() {
+    let previousDeployment = {}
+
+    if (fs.existsSync(this.configParams.OUTPUT_FILE)) {
+        console.log()
+        console.log(`------  Loading previous deployment ------ `)
+        previousDeployment = require('../' + this.configParams.OUTPUT_FILE)
+        console.log(`------  Done loading previous deployment ------ `)
+        console.log()
+    }
+
+    return previousDeployment
+  }
+
+  saveDeployment(deploymentState) {
+    const deploymentStateJSON = JSON.stringify(deploymentState, null, 2)
+    fs.writeFileSync(this.configParams.OUTPUT_FILE, deploymentStateJSON)
+  }
+
+  // --- Deployer methods ---
+
+  async getFactory(name) {
+    const factory = await ethers.getContractFactory(name, this.deployerWallet)
+    return factory
+  }
+
+  async sendAndWaitForTransaction(txPromise) {
+    const tx = await txPromise
+    const minedTx = await ethers.provider.waitForTransaction(tx.hash, this.configParams.TX_CONFIRMATIONS)
+    return minedTx
+  }
+
+  async loadOrDeploy(factory, name, abiName, deploymentState, params=[]) {
+    if (deploymentState[name] && deploymentState[name].address) {
+      console.log(`- Using previously deployed ${name} contract at address ${deploymentState[name].address}`)
+      return new ethers.Contract(
+        deploymentState[name].address,
+        factory.interface,
+        this.deployerWallet
+      );
+    }
+
+    console.log(`- Deploying ${name}...`)
+    const contract = await factory.deploy(...params, {gasPrice: this.configParams.GAS_PRICE})
+    await this.deployerWallet.provider.waitForTransaction(
+        contract.deployTransaction.hash,
+        this.configParams.TX_CONFIRMATIONS
+    )
+
+    deploymentState[name] = {
+      abi: abiName || name,
+      address: contract.address,
+      txHash: contract.deployTransaction.hash
+    }
+
+    this.saveDeployment(deploymentState)
+    return contract
+  }
+
+  async deploy(deploymentState) {
+    if (this.isMainnet()) throw Error('ERROR: !!! Wrong network !!!')
+
+    for (const token of this.configParams.COLLATERLAS) {
+        console.log()
+        console.log(`------ Deploying contracts for ${token} collateral ------`)
+        const coreContracts = await this.deployLiquityCore(deploymentState, token)
+        console.log(`- Done deploying ARTH contracts`)
+        const LQTYContracts = await this.deployLQTYContractsMainnet(deploymentState, token)
+        console.log(`- Done deploying LQTY contracts`)
+        await this.connectCoreContracts(coreContracts, LQTYContracts, token)
+        console.log(`- Done connecting ARTH contracts`)
+        await this.connectLQTYContractsMainnet(LQTYContracts)
+        console.log(`- Done connecting LQTY contracts`)
+        await this.connectLQTYContractsToCoreMainnet(LQTYContracts, coreContracts, token)
+        console.log(`- Done connecting ARTH & LQTY contracts`)
+        console.log(`------ Done deploying contracts for ${token} collateral ------`)
+        console.log()
+    }
+  }
+
+  async deployLiquityCore(deploymentState, token) {
+    const mockTokenParams =  [
+      token,
+      token,
+      this.configParams.DEPLOYER,
+      BigNumber.from(1).pow(18)
+    ];
+    const mockToken = await this.loadOrDeploy(
+      this.mockTokenFactory,
+      token,
+      'ERC20Mock',
+      deploymentState,
+      mockTokenParams
+    )
+
+    const arth = await this.loadOrDeploy(
+      this.lusdTokenFactory,
+      `ARTHStablecoin`,
+      'LiquityLUSDToken',
+      deploymentState
+    )
+
+    const maha = await this.loadOrDeploy(
+      this.mahaTokenFactory,
+      `MahaToken`,
+      'MockMaha',
+      deploymentState
+    )
+
+    const ecosystemFund = await this.loadOrDeploy(
+      this.ecosystemFundFactory,
+      'EcosystemFund',
+      'EcosystemFund',
+      deploymentState
+    )
+
+    const mahaARTHPairOracle = await this.loadOrDeploy(
+      this.mockPairOracle,
+      'UniswapPairOracle_ARTH_MAHA',
+      'MockUniswapOracle',
+      deploymentState
+    )
+    
+    const priceFeed = await this.loadOrDeploy(
+        this.priceFeedFactory,
+        `${token}PriceFeed`,
+        'PriceFeedTestnet',
+        deploymentState
+    )
+
+    const sortedTroves = await this.loadOrDeploy(
+        this.sortedTrovesFactory,
+        `${token}SortedTroves`,
+        'SortedTroves',
+        deploymentState
+    )
+
+    const troveManager = await this.loadOrDeploy(
+        this.troveManagerFactory,
+        `${token}TroveManager`,
+        'TroveManager',
+        deploymentState
+    )
+
+    const activePool = await this.loadOrDeploy(
+        this.activePoolFactory,
+        `${token}ActivePool`,
+        'ActivePool',
+        deploymentState
+    )
+
+    const stabilityPool = await this.loadOrDeploy(
+        this.stabilityPoolFactory,
+        `${token}StabilityPool`,
+        'StabilityPool',
+        deploymentState
+    )
+
+    const gasPool = await this.loadOrDeploy(
+        this.gasPoolFactory,
+        `${token}GasPool`,
+        'GasPool',
+        deploymentState
+    )
+
+    const defaultPool = await this.loadOrDeploy(
+        this.defaultPoolFactory,
+        `${token}DefaultPool`,
+        'DefaultPool',
+        deploymentState
+    )
+
+    const collSurplusPool = await this.loadOrDeploy(
+        this.collSurplusPoolFactory,
+        `${token}CollSurplusPool`,
+        'CollSurplusPool',
+        deploymentState
+    )
+
+    const borrowerOperations = await this.loadOrDeploy(
+        this.borrowerOperationsFactory,
+        `${token}BorrowerOperations`,
+        'BorrowerOperations',
+        deploymentState
+    )
+
+    const hintHelpers = await this.loadOrDeploy(
+        this.hintHelpersFactory,
+        `${token}HintHelpers`,
+        'HintHelpers',
+        deploymentState
+    )
+
+    const governanceParams = [
+        troveManager.address,
+        borrowerOperations.address
+    ]
+    const governance = await this.loadOrDeploy(
+        this.governanceFactory,
+        `${token}Governance`,
+        'Governance',
+        deploymentState,
+        governanceParams
+    )
+
+    const multiTroveGetterParams = [
+      troveManager.address,
+      sortedTroves.address
+    ]
+    const multiTroveGetter = await this.loadOrDeploy(
+      this.multiTroveGetterFactory,
+      `${token}MultiTroveGetter`,
+      'MultiTroveGetter',
+      deploymentState,
+      multiTroveGetterParams
+    )
+
+    if (!this.configParams.ETHERSCAN_BASE_URL) {
+      console.log('- No Etherscan Url defined, skipping verification')
+    } else {
+      await this.verifyContract(`EcosystemFund`, deploymentState)
+      await this.verifyContract(`UniswapPairOracle_ARTH_MAHA`, deploymentState)
+      await this.verifyContract(`${token}`, deploymentState, mockTokenParams)
+      await this.verifyContract(`ARTHStablecoin`, deploymentState)
+      await this.verifyContract(`MahaToken`, deploymentState)
+      await this.verifyContract(`${token}SortedTroves`, deploymentState)
+      await this.verifyContract(`${token}TroveManager`, deploymentState)
+      await this.verifyContract(`${token}ActivePool`, deploymentState)
+      await this.verifyContract(`${token}StabilityPool`, deploymentState)
+      await this.verifyContract(`${token}GasPool`, deploymentState)
+      await this.verifyContract(`${token}DefaultPool`, deploymentState)
+      await this.verifyContract(`${token}CollSurplusPool`, deploymentState)
+      await this.verifyContract(`${token}BorrowerOperations`, deploymentState)
+      await this.verifyContract(`${token}HintHelpers`, deploymentState)
+      await this.verifyContract(`${token}PriceFeed`, deploymentState)
+      await this.verifyContract(`${token}Governance`, deploymentState, governanceParams)
+      await this.verifyContract(`${token}MultiTroveGetter`, deploymentState, multiTroveGetterParams)
+    }
+
+    return {
+      ecosystemFund,
+      mahaARTHPairOracle,
+      arth,
+      maha,
+      mockToken,
+      governance,
+      sortedTroves,
+      troveManager,
+      activePool,
+      stabilityPool,
+      gasPool,
+      defaultPool,
+      collSurplusPool,
+      borrowerOperations,
+      hintHelpers,
+      multiTroveGetter,
+      priceFeed
+    }
+  }
+
+  async deployLQTYContractsMainnet(deploymentState, token) {
+    const lqtyStaking = await this.loadOrDeploy(
+        this.lqtyStakingFactory,
+        `${token}LQTYStaking`,
+        'LQTYStaking',
+        deploymentState
+    )
+    const lockupContractFactory = await this.loadOrDeploy(
+        this.lockupContractFactoryFactory,
+        `${token}LockupContractFactory`,
+        `LockupContractFactory`,
+        deploymentState
+    )
+    const communityIssuance = await this.loadOrDeploy(
+        this.communityIssuanceFactory,
+        `${token}CommunityIssuance`,
+        `CommunityIssuance`,
+        deploymentState
+    )
+
+    const lqtyTokenParams = [
+      communityIssuance.address,
+      lqtyStaking.address,
+      lockupContractFactory.address,
+      this.deployerWallet.address,
+      this.deployerWallet.address,
+      this.deployerWallet.address,
+    ]
+    const lqtyToken = await this.loadOrDeploy(
+      this.lqtyTokenFactory,
+      `${token}LQTYToken`,
+      'LQTYToken',
+      deploymentState,
+      lqtyTokenParams
+    )
+
+    if (!this.configParams.ETHERSCAN_BASE_URL) {
+      console.log('- No Etherscan Url defined, skipping verification')
+    } else {
+      await this.verifyContract(`${token}LQTYStaking`, deploymentState)
+      await this.verifyContract(`${token}LockupContractFactory`, deploymentState)
+      await this.verifyContract(`${token}CommunityIssuance`, deploymentState)
+      await this.verifyContract(`${token}LQTYToken`, deploymentState, lqtyTokenParams)
+    }
+
+    return {
+      lqtyStaking,
+      lockupContractFactory,
+      communityIssuance,
+      lqtyToken
+    }
+  }
+
+  // --- Connector methods ---
+
+  async isOwnershipRenounced(contract) {
+    const owner = await contract.owner()
+    return owner == ZERO_ADDRESS
+  }
+
+  async connectCoreContracts(ARTHContracts, LQTYContracts, token) {
+    const gasPrice = this.configParams.GAS_PRICE
+
+    await this.sendAndWaitForTransaction(
+        ARTHContracts.governance.setPriceFeed(ARTHContracts.priceFeed.address, {gasPrice})
+    )
+
+    await this.sendAndWaitForTransaction(ARTHContracts.governance.setStabilityFeeToken(
+        ARTHContracts.maha.address,
+        ARTHContracts.mahaARTHPairOracle.address,
+        {gasPrice}
+    ))
+
+    await this.sendAndWaitForTransaction(ARTHContracts.governance.setFund(
+        ARTHContracts.ecosystemFund.address,
+        {gasPrice}
+    ))
+
+    await this.sendAndWaitForTransaction(ARTHContracts.arth.toggleBorrowerOperations(
+     ARTHContracts.borrowerOperations.address,
+     { gasPrice } 
+    ))
+
+    await this.sendAndWaitForTransaction(ARTHContracts.arth.toggleTroveManager(
+      ARTHContracts.troveManager.address,
+      { gasPrice } 
+     ))
+
+     await this.sendAndWaitForTransaction(ARTHContracts.arth.toggleStabilityPool(
+      ARTHContracts.stabilityPool.address,
+      { gasPrice } 
+     ))
+
+    // set TroveManager addr in Sorted Troves.
+    await this.isOwnershipRenounced(ARTHContracts.sortedTroves) ||
+      await this.sendAndWaitForTransaction(ARTHContracts.sortedTroves.setParams(
+        maxBytes32,
+        ARTHContracts.troveManager.address,
+        ARTHContracts.borrowerOperations.address,
+        {gasPrice}
+      ))
+
+    // set TroveManager addr in TroveManager.
+    await this.isOwnershipRenounced(ARTHContracts.troveManager) ||
+      await this.sendAndWaitForTransaction(ARTHContracts.troveManager.setAddresses(
+        ARTHContracts.borrowerOperations.address,
+        ARTHContracts.activePool.address,
+        ARTHContracts.defaultPool.address,
+        ARTHContracts.stabilityPool.address,
+        ARTHContracts.gasPool.address,
+        ARTHContracts.collSurplusPool.address,
+        ARTHContracts.arth.address,
+        ARTHContracts.sortedTroves.address,
+        ARTHContracts.governance.address,
+        ARTHContracts.mockToken.address,
+        {gasPrice}
+      ))
+
+    // Set contracts in BorrowerOperations.
+    await this.isOwnershipRenounced(ARTHContracts.borrowerOperations) ||
+      await this.sendAndWaitForTransaction(ARTHContracts.borrowerOperations.setAddresses(
+        ARTHContracts.troveManager.address,
+        ARTHContracts.activePool.address,
+        ARTHContracts.defaultPool.address,
+        ARTHContracts.stabilityPool.address,
+        ARTHContracts.gasPool.address,
+        ARTHContracts.collSurplusPool.address,
+        ARTHContracts.sortedTroves.address,
+        ARTHContracts.arth.address,
+        ARTHContracts.mockToken.address,
+        ARTHContracts.governance.address,
+        {gasPrice}
+      ))
+
+    // Set contracts in StabilityPool.
+    await this.isOwnershipRenounced(ARTHContracts.stabilityPool) ||
+      await this.sendAndWaitForTransaction(ARTHContracts.stabilityPool.setAddresses(
+        ARTHContracts.borrowerOperations.address,
+        ARTHContracts.troveManager.address,
+        ARTHContracts.activePool.address,
+        ARTHContracts.arth.address,
+        ARTHContracts.sortedTroves.address,
+        LQTYContracts.communityIssuance.address,
+        ARTHContracts.mockToken.address,
+        ARTHContracts.governance.address,
+        {gasPrice}
+      ))
+
+    // Set contracts in ActivePool.
+    await this.isOwnershipRenounced(ARTHContracts.activePool) ||
+      await this.sendAndWaitForTransaction(ARTHContracts.activePool.setAddresses(
+        ARTHContracts.borrowerOperations.address,
+        ARTHContracts.troveManager.address,
+        ARTHContracts.stabilityPool.address,
+        ARTHContracts.defaultPool.address,
+        ARTHContracts.collSurplusPool.address,
+        ARTHContracts.mockToken.address,
+        {gasPrice}
+      ))
+
+    // Set contracts in DefaultPool.
+    await this.isOwnershipRenounced(ARTHContracts.defaultPool) ||
+      await this.sendAndWaitForTransaction(ARTHContracts.defaultPool.setAddresses(
+        ARTHContracts.troveManager.address,
+        ARTHContracts.activePool.address,
+        ARTHContracts.mockToken.address,
+        {gasPrice}
+      ))
+
+    // Set contracts in CollSurplusPool.
+    await this.isOwnershipRenounced(ARTHContracts.collSurplusPool) ||
+      await this.sendAndWaitForTransaction(ARTHContracts.collSurplusPool.setAddresses(
+        ARTHContracts.borrowerOperations.address,
+        ARTHContracts.troveManager.address,
+        ARTHContracts.activePool.address,
+        ARTHContracts.mockToken.address,
+        {gasPrice}
+      ))
+
+    // Set contracts in HintHelpers.
+    await this.isOwnershipRenounced(ARTHContracts.hintHelpers) ||
+      await this.sendAndWaitForTransaction(ARTHContracts.hintHelpers.setAddresses(
+        ARTHContracts.sortedTroves.address,
+        ARTHContracts.troveManager.address,
+        {gasPrice}
+      ))
+  }
+
+  async connectLQTYContractsMainnet(LQTYContracts) {
+    const gasPrice = this.configParams.GAS_PRICE
+
+    await this.isOwnershipRenounced(LQTYContracts.lqtyStaking) ||
+      await this.sendAndWaitForTransaction(LQTYContracts.lockupContractFactory.setLQTYTokenAddress(
+        LQTYContracts.
+        lqtyToken.address,
+        {gasPrice}
+      ))
+  }
+
+  async connectLQTYContractsToCoreMainnet(LQTYContracts, ARTHContracts, token) {
+    const gasPrice = this.configParams.GAS_PRICE
+
+    await this.isOwnershipRenounced(LQTYContracts.lqtyStaking) ||
+      await this.sendAndWaitForTransaction(LQTYContracts.lqtyStaking.setAddresses(
+        LQTYContracts.lqtyToken.address,
+        ARTHContracts.arth.address,
+        ARTHContracts.troveManager.address,
+        ARTHContracts.borrowerOperations.address,
+        ARTHContracts.activePool.address,
+        ARTHContracts.mockToken.address,
+        {gasPrice}
+      ))
+
+    await this.isOwnershipRenounced(LQTYContracts.communityIssuance) ||
+      await this.sendAndWaitForTransaction(LQTYContracts.communityIssuance.setAddresses(
+        LQTYContracts.lqtyToken.address,
+        ARTHContracts.stabilityPool.address,
+        {gasPrice}
+      ))
+  }
+
+  // --- Verify on Ethrescan ---
+
+  async verifyContract(name, deploymentState, constructorArguments=[]) {
+    if (!deploymentState[name] || !deploymentState[name].address) {
+      console.error(`- No deployment state for contract ${name}!!`)
+      return
+    }
+
+    if (deploymentState[name].verification) {
+      console.log(`- Contract ${name} already verified`)
+      return
+    }
+
+    try {
+      await this.hre.run("verify:verify", {
+        address: deploymentState[name].address,
+        constructorArguments,
+      })
+    } catch (error) {
+      console.log(error)
+      if (error.name != 'NomicLabsHardhatPluginError') {
+        console.error(`- Error verifying: ${error.name}`)
+        console.error(error)
+        return
+      }
+    }
+
+    deploymentState[name].verification = `${this.configParams.ETHERSCAN_BASE_URL}/${deploymentState[name].address}#code`
+    this.saveDeployment(deploymentState)
+  }
+
+  // --- Helpers ---
+
+  async logContractObjects (contracts) {
+    console.log(`- Contract objects addresses:`)
+    for ( const contractName of Object.keys(contracts)) {
+      console.log(`- Contract: ${contractName}: ${contracts[contractName].address}`);
+    }
+  }
+}
+
+module.exports = MainnetDeploymentHelper


### PR DESCRIPTION
- Remove controller from contracts.
- Change gas pool contract as we don't need those methods to go around access control in liquity's LUSD.
- Remove gasPool functions from other contracts like TroveManager, BorrowerOperations etc.