### PR TITLE
Feat modify oracles

### DIFF
--- a/packages/contracts/contracts/Dependencies/Babylonian.sol
+++ b/packages/contracts/contracts/Dependencies/Babylonian.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+/// @dev computes square roots using the babylonian method
+/// https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method
+library Babylonian {
+    function sqrt(uint256 y) internal pure returns (uint256 z) {
+        if (y > 3) {
+            z = y;
+            uint256 x = y / 2 + 1;
+            while (x < z) {
+                z = x;
+                x = (y / x + x) / 2;
+            }
+        } else if (y != 0) {
+            z = 1;
+        }
+        // else z = 0
+    }
+}

--- a/packages/contracts/contracts/Dependencies/FixedPoint.sol
+++ b/packages/contracts/contracts/Dependencies/FixedPoint.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+import './Babylonian.sol';
+
+/// @dev A library for handling binary fixed point numbers (https://en.wikipedia.org/wiki/Q_(number_format))
+library FixedPoint {
+    // range: [0, 2**112 - 1]
+    // resolution: 1 / 2**112
+    struct uq112x112 {
+        uint224 _x;
+    }
+
+    // range: [0, 2**144 - 1]
+    // resolution: 1 / 2**112
+    struct uq144x112 {
+        uint256 _x;
+    }
+
+    uint8 private constant RESOLUTION = 112;
+    uint256 private constant Q112 = uint256(1) << RESOLUTION;
+    uint256 private constant Q224 = Q112 << RESOLUTION;
+
+    // encode a uint112 as a UQ112x112
+    function encode(uint112 x) internal pure returns (uq112x112 memory) {
+        return uq112x112(uint224(x) << RESOLUTION);
+    }
+
+    // encodes a uint144 as a UQ144x112
+    function encode144(uint144 x) internal pure returns (uq144x112 memory) {
+        return uq144x112(uint256(x) << RESOLUTION);
+    }
+
+    // divide a UQ112x112 by a uint112, returning a UQ112x112
+    function div(uq112x112 memory self, uint112 x)
+        internal
+        pure
+        returns (uq112x112 memory)
+    {
+        require(x != 0, 'FixedPoint: DIV_BY_ZERO');
+        return uq112x112(self._x / uint224(x));
+    }
+
+    // multiply a UQ112x112 by a uint, returning a UQ144x112
+    // reverts on overflow
+    function mul(uq112x112 memory self, uint256 y)
+        internal
+        pure
+        returns (uq144x112 memory)
+    {
+        uint256 z;
+        require(
+            y == 0 || (z = uint256(self._x) * y) / y == uint256(self._x),
+            'FixedPoint: MULTIPLICATION_OVERFLOW'
+        );
+        return uq144x112(z);
+    }
+
+    // returns a UQ112x112 which represents the ratio of the numerator to the denominator
+    // equivalent to encode(numerator).div(denominator)
+    function fraction(uint112 numerator, uint112 denominator)
+        internal
+        pure
+        returns (uq112x112 memory)
+    {
+        require(denominator > 0, 'FixedPoint: DIV_BY_ZERO');
+        return uq112x112((uint224(numerator) << RESOLUTION) / denominator);
+    }
+
+    // decode a UQ112x112 into a uint112 by truncating after the radix point
+    function decode(uq112x112 memory self) internal pure returns (uint112) {
+        return uint112(self._x >> RESOLUTION);
+    }
+
+    // decode a UQ144x112 into a uint144 by truncating after the radix point
+    function decode144(uq144x112 memory self) internal pure returns (uint144) {
+        return uint144(self._x >> RESOLUTION);
+    }
+
+    // take the reciprocal of a UQ112x112
+    function reciprocal(uq112x112 memory self)
+        internal
+        pure
+        returns (uq112x112 memory)
+    {
+        require(self._x != 0, 'FixedPoint: ZERO_RECIPROCAL');
+        return uq112x112(uint224(Q224 / self._x));
+    }
+
+    // square root of a UQ112x112
+    function sqrt(uq112x112 memory self)
+        internal
+        pure
+        returns (uq112x112 memory)
+    {
+        return uq112x112(uint224(Babylonian.sqrt(uint256(self._x)) << 56));
+    }
+}

--- a/packages/contracts/contracts/Dependencies/IUniswapV2Factory.sol
+++ b/packages/contracts/contracts/Dependencies/IUniswapV2Factory.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+interface IUniswapV2Factory {
+    event PairCreated(
+        address indexed token0,
+        address indexed token1,
+        address pair,
+        uint256
+    );
+
+    function feeTo() external view returns (address);
+
+    function feeToSetter() external view returns (address);
+
+    function getPair(address tokenA, address tokenB)
+        external
+        view
+        returns (address pair);
+
+    function allPairs(uint256) external view returns (address pair);
+
+    function allPairsLength() external view returns (uint256);
+
+    function createPair(address tokenA, address tokenB)
+        external
+        returns (address pair);
+
+    function setFeeTo(address) external;
+
+    function setFeeToSetter(address) external;
+}

--- a/packages/contracts/contracts/Dependencies/IUniswapV2Pair.sol
+++ b/packages/contracts/contracts/Dependencies/IUniswapV2Pair.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+interface IUniswapV2Pair {
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        uint256 value
+    );
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    function name() external pure returns (string memory);
+
+    function symbol() external pure returns (string memory);
+
+    function decimals() external pure returns (uint8);
+
+    function totalSupply() external view returns (uint256);
+
+    function balanceOf(address owner) external view returns (uint256);
+
+    function allowance(address owner, address spender)
+        external
+        view
+        returns (uint256);
+
+    function approve(address spender, uint256 value) external returns (bool);
+
+    function transfer(address to, uint256 value) external returns (bool);
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 value
+    ) external returns (bool);
+
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+
+    function PERMIT_TYPEHASH() external pure returns (bytes32);
+
+    function nonces(address owner) external view returns (uint256);
+
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    event Mint(address indexed sender, uint256 amount0, uint256 amount1);
+    event Burn(
+        address indexed sender,
+        uint256 amount0,
+        uint256 amount1,
+        address indexed to
+    );
+    event Swap(
+        address indexed sender,
+        uint256 amount0In,
+        uint256 amount1In,
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address indexed to
+    );
+    event Sync(uint112 reserve0, uint112 reserve1);
+
+    function MINIMUM_LIQUIDITY() external pure returns (uint256);
+
+    function factory() external view returns (address);
+
+    function token0() external view returns (address);
+
+    function token1() external view returns (address);
+
+    function getReserves()
+        external
+        view
+        returns (
+            uint112 reserve0,
+            uint112 reserve1,
+            uint32 blockTimestampLast
+        );
+
+    function price0CumulativeLast() external view returns (uint256);
+
+    function price1CumulativeLast() external view returns (uint256);
+
+    function kLast() external view returns (uint256);
+
+    function mint(address to) external returns (uint256 liquidity);
+
+    function burn(address to)
+        external
+        returns (uint256 amount0, uint256 amount1);
+
+    function swap(
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address to,
+        bytes calldata data
+    ) external;
+
+    function skim(address to) external;
+
+    function sync() external;
+
+    function initialize(address, address) external;
+}

--- a/packages/contracts/contracts/Dependencies/UniswapV2Library.sol
+++ b/packages/contracts/contracts/Dependencies/UniswapV2Library.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+import './SafeMath.sol';
+import './IUniswapV2Pair.sol';
+import './IUniswapV2Factory.sol';
+
+library UniswapV2Library {
+    using SafeMath for uint256;
+
+    /// @dev Returns sorted token addresses, used to handle return values from
+    /// pairs sorted in this order
+    function sortTokens(address tokenA, address tokenB)
+        internal
+        pure
+        returns (address token0, address token1)
+    {
+        require(tokenA != tokenB, 'UniswapV2Library: IDENTICAL_ADDRESSES');
+        (token0, token1) = tokenA < tokenB
+            ? (tokenA, tokenB)
+            : (tokenB, tokenA);
+        require(token0 != address(0), 'UniswapV2Library: ZERO_ADDRESS');
+    }
+
+    /// @dev Less efficient than the CREATE2 method below
+    function pairFor(
+        address factory,
+        address tokenA,
+        address tokenB
+    ) internal view returns (address pair) {
+        (address token0, address token1) = sortTokens(tokenA, tokenB);
+        pair = IUniswapV2Factory(factory).getPair(token0, token1);
+    }
+
+    /// @dev Calculates the CREATE2 address for a pair without making any external calls
+    function pairForCreate2(
+        address factory,
+        address tokenA,
+        address tokenB
+    ) internal pure returns (address pair) {
+        (address token0, address token1) = sortTokens(tokenA, tokenB);
+        pair = address(
+            bytes20(
+                keccak256(
+                    abi.encodePacked(
+                        hex'ff',
+                        factory,
+                        keccak256(abi.encodePacked(token0, token1)),
+                        hex'96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f' // init code hash
+                    )
+                )
+            )
+        ); // this matches the CREATE2 in UniswapV2Factory.createPair
+    }
+
+    /// @dev Fetches and sorts the reserves for a pair
+    function getReserves(
+        address factory,
+        address tokenA,
+        address tokenB
+    ) internal view returns (uint256 reserveA, uint256 reserveB) {
+        (address token0, ) = sortTokens(tokenA, tokenB);
+        (uint256 reserve0, uint256 reserve1, ) =
+            IUniswapV2Pair(pairFor(factory, tokenA, tokenB)).getReserves();
+        (reserveA, reserveB) = tokenA == token0
+            ? (reserve0, reserve1)
+            : (reserve1, reserve0);
+    }
+
+    /// @dev Given some amount of an asset and pair reserves, returns an equivalent
+    /// amount of the other asset
+    function quote(
+        uint256 amountA,
+        uint256 reserveA,
+        uint256 reserveB
+    ) internal pure returns (uint256 amountB) {
+        require(amountA > 0, 'UniswapV2Library: INSUFFICIENT_AMOUNT');
+        require(
+            reserveA > 0 && reserveB > 0,
+            'UniswapV2Library: INSUFFICIENT_LIQUIDITY'
+        );
+        amountB = amountA.mul(reserveB) / reserveA;
+    }
+
+    /// @dev Given an input amount of an asset and pair reserves, returns the
+    /// maximum output amount of the other asset
+    function getAmountOut(
+        uint256 amountIn,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) internal pure returns (uint256 amountOut) {
+        require(amountIn > 0, 'UniswapV2Library: INSUFFICIENT_INPUT_AMOUNT');
+        require(
+            reserveIn > 0 && reserveOut > 0,
+            'UniswapV2Library: INSUFFICIENT_LIQUIDITY'
+        );
+        uint256 amountInWithFee = amountIn.mul(997);
+        uint256 numerator = amountInWithFee.mul(reserveOut);
+        uint256 denominator = reserveIn.mul(1000).add(amountInWithFee);
+        amountOut = numerator / denominator;
+    }
+
+    /// @dev Given an output amount of an asset and pair reserves, returns a required
+    /// input amount of the other asset
+    function getAmountIn(
+        uint256 amountOut,
+        uint256 reserveIn,
+        uint256 reserveOut
+    ) internal pure returns (uint256 amountIn) {
+        require(amountOut > 0, 'UniswapV2Library: INSUFFICIENT_OUTPUT_AMOUNT');
+        require(
+            reserveIn > 0 && reserveOut > 0,
+            'UniswapV2Library: INSUFFICIENT_LIQUIDITY'
+        );
+        uint256 numerator = reserveIn.mul(amountOut).mul(1000);
+        uint256 denominator = reserveOut.sub(amountOut).mul(997);
+        amountIn = (numerator / denominator).add(1);
+    }
+
+    /// @dev Performs chained getAmountOut calculations on any number of pairs
+    function getAmountsOut(
+        address factory,
+        uint256 amountIn,
+        address[] memory path
+    ) internal view returns (uint256[] memory amounts) {
+        require(path.length >= 2, 'UniswapV2Library: INVALID_PATH');
+        amounts = new uint256[](path.length);
+        amounts[0] = amountIn;
+        for (uint256 i; i < path.length - 1; i++) {
+            (uint256 reserveIn, uint256 reserveOut) =
+                getReserves(factory, path[i], path[i + 1]);
+            amounts[i + 1] = getAmountOut(amounts[i], reserveIn, reserveOut);
+        }
+    }
+
+    /// @dev Performs chained getAmountIn calculations on any number of pairs
+    function getAmountsIn(
+        address factory,
+        uint256 amountOut,
+        address[] memory path
+    ) internal view returns (uint256[] memory amounts) {
+        require(path.length >= 2, 'UniswapV2Library: INVALID_PATH');
+        amounts = new uint256[](path.length);
+        amounts[amounts.length - 1] = amountOut;
+        for (uint256 i = path.length - 1; i > 0; i--) {
+            (uint256 reserveIn, uint256 reserveOut) =
+                getReserves(factory, path[i - 1], path[i]);
+            amounts[i - 1] = getAmountIn(amounts[i], reserveIn, reserveOut);
+        }
+    }
+}

--- a/packages/contracts/contracts/Dependencies/UniswapV2OracleLibrary.sol
+++ b/packages/contracts/contracts/Dependencies/UniswapV2OracleLibrary.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+import './FixedPoint.sol';
+import './IUniswapV2Pair.sol';
+
+/// @dev Library with helper methods for oracles that are concerned
+/// with computing average prices.
+library UniswapV2OracleLibrary {
+    using FixedPoint for *;
+
+    /// @dev Helper function that returns the current block timestamp
+    /// within the range of uint32, i.e. [0, 2**32 - 1]
+    function currentBlockTimestamp() internal view returns (uint32) {
+        return uint32(block.timestamp % 2**32);
+    }
+
+    /// @dev Produces the cumulative price using counterfactuals to save gas
+    /// and avoid a call to sync.
+    function currentCumulativePrices(address pair)
+        internal
+        view
+        returns (
+            uint256 price0Cumulative,
+            uint256 price1Cumulative,
+            uint32 blockTimestamp
+        )
+    {
+        blockTimestamp = currentBlockTimestamp();
+        price0Cumulative = IUniswapV2Pair(pair).price0CumulativeLast();
+        price1Cumulative = IUniswapV2Pair(pair).price1CumulativeLast();
+
+        // if time has elapsed since the last update on the pair, mock the accumulated price values
+        (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast) =
+            IUniswapV2Pair(pair).getReserves();
+        if (blockTimestampLast != blockTimestamp) {
+            // subtraction overflow is desired
+            uint32 timeElapsed = blockTimestamp - blockTimestampLast;
+            // addition overflow is desired
+            // counterfactual
+            price0Cumulative +=
+                uint256(FixedPoint.fraction(reserve1, reserve0)._x) *
+                timeElapsed;
+            // counterfactual
+            price1Cumulative +=
+                uint256(FixedPoint.fraction(reserve0, reserve1)._x) *
+                timeElapsed;
+        }
+    }
+}

--- a/packages/contracts/contracts/PriceFeed.sol
+++ b/packages/contracts/contracts/PriceFeed.sol
@@ -28,18 +28,21 @@ contract PriceFeed is Ownable, CheckContract, BaseMath, IPriceFeed {
     string public constant NAME = "PriceFeed";
 
     // Mainnet Chainlink aggregator.
-    // This will be BNB/USD in case of MAHA Collateral and MAHA/WBNB Unipair.
-    // Else will be BUSD/USD in case of BUSD Collatera.
+    // This will be BNB/USD in case of MAHA Collateral because we use MAHA/WBNB pair.
+    // Else will be BUSD/USD in case of BUSD Collateral.
     AggregatorV3Interface public priceAggregator;
 
-    address public baseAsset;  // MAHA in case of MAHA Collateral using MAHA/WBNB pair.
-    address public quoteAsset; // WBNB in case of MAHA Collateral using MAHA/WBNB pair.
+    // MAHA in case of MAHA Collateral using MAHA/WBNB pair.
+    address public baseAsset;
+    // WBNB in case of MAHA Collateral using MAHA/WBNB pair.
+    address public quoteAsset;
 
     uint256 public baseAssetDecimals;
     uint256 public quoteAssetDecimals;
 
     // Oracle to fetch price from DEX.
-    IUniswapPairOracle public uniPairOracle;  // MAHA/WBNB in case of MAHA Collateral else 0.
+    // MAHA/WBNB in case of MAHA Collateral else ZERO ADDRESS.
+    IUniswapPairOracle public uniPairOracle;
 
     // GMU oracle.
     IOracle public gmuOracle;

--- a/packages/contracts/contracts/PriceFeed.sol
+++ b/packages/contracts/contracts/PriceFeed.sol
@@ -102,7 +102,7 @@ contract PriceFeed is Ownable, CheckContract, BaseMath, IPriceFeed {
     // --- Helper functions ---
 
     function _fetchPrice() internal view returns (uint256) {
-        if (address(uniPairOracle) != address(0)) return _fetchPriceWithoutUniPair();
+        if (address(uniPairOracle) == address(0)) return _fetchPriceWithoutUniPair();
 
         return _fetchPriceWithUniPair();
     }

--- a/packages/contracts/contracts/UniswapPairOracle.sol
+++ b/packages/contracts/contracts/UniswapPairOracle.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+import {FixedPoint} from './Dependencies/FixedPoint.sol';
+import {IUniswapPairOracle} from './Dependencies/IUniswapPairOracle.sol';
+import {UniswapV2Library} from './Dependencies/UniswapV2Library.sol';
+import {IUniswapV2Pair} from './Dependencies/IUniswapV2Pair.sol';
+import {
+    UniswapV2OracleLibrary
+} from './Dependencies/UniswapV2OracleLibrary.sol';
+import {
+    IUniswapV2Factory
+} from './Dependencies/IUniswapV2Factory.sol';
+
+/// @dev Fixed window oracle that recomputes the average price for the entire period once every period
+///  Note that the price average is only guaranteed to be over at least 1 period, but may be over a longer period
+contract UniswapPairOracle is IUniswapPairOracle {
+    using FixedPoint for *;
+
+    IUniswapV2Pair public immutable pair;
+    FixedPoint.uq112x112 public price0Average;
+    FixedPoint.uq112x112 public price1Average;
+
+    uint32 public blockTimestampLast;
+    uint256 public PERIOD = 3600; // 1 hour TWAP (time-weighted average price)
+    uint256 public CONSULT_LENIENCY = 120; // Used for being able to consult past the period end
+    uint256 public price0CumulativeLast;
+    uint256 public price1CumulativeLast;
+
+    bool public ALLOW_STALE_CONSULTS = false; // If false, consult() will fail if the TWAP is stale
+
+    address public immutable token0;
+    address public immutable token1;
+
+    address ownerAddress;
+    address timelockAddress;
+
+    modifier onlyByOwnerOrGovernance() {
+        require(
+            msg.sender == ownerAddress || msg.sender == timelockAddress,
+            'You are not an owner or the governance timelock'
+        );
+        _;
+    }
+
+    constructor(
+        address factory,
+        address tokenA,
+        address tokenB,
+        address _ownerAddress,
+        address _timelockAddress
+    ) public {
+        IUniswapV2Pair _pair =
+            IUniswapV2Pair(UniswapV2Library.pairFor(factory, tokenA, tokenB));
+        pair = _pair;
+        token0 = _pair.token0();
+        token1 = _pair.token1();
+        price0CumulativeLast = _pair.price0CumulativeLast(); // Fetch the current accumulated price value (1 / 0)
+        price1CumulativeLast = _pair.price1CumulativeLast(); // Fetch the current accumulated price value (0 / 1)
+        uint112 reserve0;
+        uint112 reserve1;
+        (reserve0, reserve1, blockTimestampLast) = _pair.getReserves();
+        require(
+            reserve0 != 0 && reserve1 != 0,
+            'UniswapPairOracle: NO_RESERVES'
+        ); // Ensure that there's liquidity in the pair
+
+        ownerAddress = _ownerAddress;
+        timelockAddress = _timelockAddress;
+    }
+
+    /**
+     * External.
+     */
+
+    function setOwner(address _ownerAddress) external onlyByOwnerOrGovernance {
+        ownerAddress = _ownerAddress;
+    }
+
+    function setTimelock(address _timelockAddress)
+        external
+        onlyByOwnerOrGovernance
+    {
+        timelockAddress = _timelockAddress;
+    }
+
+    function setPeriod(uint256 _period) external onlyByOwnerOrGovernance {
+        PERIOD = _period;
+    }
+
+    function setConsultLeniency(uint256 _consult_leniency)
+        external
+        onlyByOwnerOrGovernance
+    {
+        CONSULT_LENIENCY = _consult_leniency;
+    }
+
+    function setAllowStaleConsults(bool _allow_stale_consults)
+        external
+        onlyByOwnerOrGovernance
+    {
+        ALLOW_STALE_CONSULTS = _allow_stale_consults;
+    }
+
+    function update() external override {
+        (
+            uint256 price0Cumulative,
+            uint256 price1Cumulative,
+            uint32 blockTimestamp
+        ) = UniswapV2OracleLibrary.currentCumulativePrices(address(pair));
+        uint32 timeElapsed = blockTimestamp - blockTimestampLast; // Overflow is desired
+
+        // Ensure that at least one full period has passed since the last update
+        require(timeElapsed >= PERIOD, 'UniswapPairOracle: PERIOD_NOT_ELAPSED');
+
+        // Overflow is desired, casting never truncates
+        // Cumulative price is in (uq112x112 price * seconds) units so we simply wrap it after division by time elapsed
+        price0Average = FixedPoint.uq112x112(
+            uint224((price0Cumulative - price0CumulativeLast) / timeElapsed)
+        );
+        price1Average = FixedPoint.uq112x112(
+            uint224((price1Cumulative - price1CumulativeLast) / timeElapsed)
+        );
+
+        price0CumulativeLast = price0Cumulative;
+        price1CumulativeLast = price1Cumulative;
+        blockTimestampLast = blockTimestamp;
+    }
+
+    // Note this will always return 0 before update has been called successfully for the first time.
+    function consult(address token, uint256 amountIn)
+        external
+        view
+        override
+        returns (uint256 amountOut)
+    {
+        uint32 blockTimestamp = UniswapV2OracleLibrary.currentBlockTimestamp();
+        uint32 timeElapsed = blockTimestamp - blockTimestampLast; // Overflow is desired
+
+        // Ensure that the price is not stale
+        require((timeElapsed < (PERIOD + CONSULT_LENIENCY)) || ALLOW_STALE_CONSULTS, 'UniswapPairOracle: PRICE_IS_STALE_NEED_TO_CALL_UPDATE');
+
+        if (token == token0) {
+            amountOut = price0Average.mul(amountIn).decode144();
+        } else {
+            require(token == token1, 'UniswapPairOracle: INVALID_TOKEN');
+            amountOut = price1Average.mul(amountIn).decode144();
+        }
+    }
+
+    /**
+     * Public.
+     */
+
+    // Check if update() can be called instead of wasting gas calling it
+    function canUpdate() public view override returns (bool) {
+        uint32 blockTimestamp = UniswapV2OracleLibrary.currentBlockTimestamp();
+        uint32 timeElapsed = blockTimestamp - blockTimestampLast; // Overflow is desired
+        return (timeElapsed >= PERIOD);
+    }
+}


### PR DESCRIPTION
- Add uniswap oracle in price feed.
- Price feed uses chainlink oracle only if uniswap oracle not set.
- If uniswap oracle set, then fetches price from all three and uses path Uniswap-Chainlink-GMU for final price calculation.
- Add individual price fetched are maintained in TARGET_DIGITS precision.