### PR TITLE
Feat: add cap limiters and checks before minting ARTH at various stages.

### DIFF
--- a/packages/contracts/contracts/ActivePool.sol
+++ b/packages/contracts/contracts/ActivePool.sol
@@ -8,7 +8,7 @@ import "./Dependencies/Ownable.sol";
 import "./Dependencies/AccessControl.sol";
 
 import "./Dependencies/CheckContract.sol";
-import "./Dependencies/IGovernance.sol";
+import "./Interfaces/IGovernance.sol";
 import "./Dependencies/IERC20.sol";
 
 /*

--- a/packages/contracts/contracts/BorrowerOperations.sol
+++ b/packages/contracts/contracts/BorrowerOperations.sol
@@ -515,6 +515,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
                 // Else split and send half to fund and half to frontend.
                 uint256 feeToFrontEnd = LUSDFee.mul(50).div(100);
                 uint256 remainingFee = LUSDFee.sub(feeToFrontEnd);
+                require(governance.getAllowMinting(), "Minting not allowed");
                 _lusdToken.mint(_frontEndTag, feeToFrontEnd); // send half to frontend.
                 _sendFeeToFund(_lusdToken, remainingFee); // And reamining half to fund.
             }
@@ -524,6 +525,8 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
     }
 
     function _sendFeeToFund(ILiquityLUSDToken _lusdToken, uint256 _LUSDFeeToFund) internal {
+        require(governance.getAllowMinting(), "Minting not allowed");
+
         // 1. Mint the fee tokens to governance.
         _lusdToken.mint(address(governance), _LUSDFeeToFund);
         // 2. The governance nows has the fee tokens, and hence can be sent to funds by governance.
@@ -606,6 +609,7 @@ contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOpe
         uint256 _netDebtIncrease
     ) internal {
         _activePool.increaseLUSDDebt(_netDebtIncrease);
+        require(governance.getAllowMinting(), "Minting not allowed");
         _lusdToken.mint(_account, _LUSDAmount);
     }
 

--- a/packages/contracts/contracts/DailySupplyValidator.sol
+++ b/packages/contracts/contracts/DailySupplyValidator.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.0;
+
+import "./Interfaces/ILiquityLUSDToken.sol";
+import "./Dependencies/SafeMath.sol";
+import "./Dependencies/CheckContract.sol";
+import "./Interfaces/ISupplyValidator.sol";
+import "./Dependencies/TransferableOwnable.sol";
+
+contract DailySupplyValidator is ISupplyValidator, CheckContract, TransferableOwnable {
+    using SafeMath for uint256;
+
+    uint256 public dailyMintCap;
+    uint256 public supplyMintedToday;
+    uint256 public currentDayTimestamp;
+
+    address public lusdToken;
+
+    event SupplyMintedTodayReset(uint256 timestamp);
+    event DailyMintCapChanged(uint256 oldValue, uint256 newValue, uint256 timestamp);
+    event CurrentDayTimestampUpdated(uint256 oldValue, uint256 newValue, uint256 timestamp);
+
+    constructor(uint256 _dailyMintCap, uint256 _supplyMintedToday, address _lusdToken) {
+        lusdToken = _lusdToken;
+        dailyMintCap = _dailyMintCap;
+        supplyMintedToday = _supplyMintedToday;
+
+        _updateCurrentDayTimestamp();
+    }
+
+    function setDailyMintCap(uint256 newCap) external onlyOwner override {
+        uint256 oldValue = dailyMintCap;
+        dailyMintCap = newCap;
+        emit DailyMintCapChanged(oldValue, newCap, block.timestamp);
+    }
+
+    function validateMintAndUpdate(uint256 amount) external override {
+        require(amount > 0, "Amount == 0");
+        require(msg.sender == lusdToken, "Unauthorized");
+        require(block.timestamp >= currentDayTimestamp, "Invalid time");
+
+        if (block.timestamp.sub(currentDayTimestamp) < 86400) {
+            _requireNewDailySupplyBelowCap(amount);
+        } else {
+            _updateCurrentDayTimestamp();
+            _resetSupplyMintedToday();
+        }
+
+        supplyMintedToday = supplyMintedToday.add(amount);
+    }
+
+    function updateBurntSupply(uint256 amount) external override {
+        require(amount > 0, "Amount == 0");
+        require(msg.sender == lusdToken, "Unauthorized");
+        require(block.timestamp >= currentDayTimestamp, "Invalid time");
+
+        if (block.timestamp.sub(currentDayTimestamp) < 86400) {
+            supplyMintedToday = supplyMintedToday.sub(amount);
+        } else {
+           _updateCurrentDayTimestamp();
+           _resetSupplyMintedToday();
+        }
+    }
+
+    function _requireNewDailySupplyBelowCap(uint256 newAmount) internal view {
+        uint256 newSupply = supplyMintedToday.add(newAmount);
+        require(
+            newSupply < dailyMintCap,
+            "Daily mint cap passed"
+        );
+    }
+
+    function _updateCurrentDayTimestamp() internal {
+        uint256 oldValue = currentDayTimestamp;
+        currentDayTimestamp = (block.timestamp / 86400) * 86400;
+        emit CurrentDayTimestampUpdated(oldValue, currentDayTimestamp, block.timestamp);
+    }
+
+    function _resetSupplyMintedToday() internal {
+        uint256 oldValue = supplyMintedToday;
+        supplyMintedToday = 0;
+        emit SupplyMintedTodayReset(block.timestamp);
+    }
+}

--- a/packages/contracts/contracts/DailySupplyValidator.sol
+++ b/packages/contracts/contracts/DailySupplyValidator.sol
@@ -78,7 +78,6 @@ contract DailySupplyValidator is ISupplyValidator, CheckContract, TransferableOw
     }
 
     function _resetSupplyMintedToday() internal {
-        uint256 oldValue = supplyMintedToday;
         supplyMintedToday = 0;
         emit SupplyMintedTodayReset(block.timestamp);
     }

--- a/packages/contracts/contracts/Interfaces/IActivePool.sol
+++ b/packages/contracts/contracts/Interfaces/IActivePool.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.0;
 import "./IPool.sol";
 
 interface IActivePool is IPool {
+    event GovernanceContractChanged(address _newGovernanceAddress);
     event BorrowerOperationsAddressChanged(address _newBorrowerOperationsAddress);
     event TroveManagerAddressChanged(address _newTroveManagerAddress);
     event ActivePoolLUSDDebtUpdated(uint256 _LUSDDebt);

--- a/packages/contracts/contracts/Interfaces/ILiquityLUSDToken.sol
+++ b/packages/contracts/contracts/Interfaces/ILiquityLUSDToken.sol
@@ -8,7 +8,8 @@ import "../Dependencies/IERC2612.sol";
 interface ILiquityLUSDToken is IERC20, IERC2612 {
 
     // --- Events ---
-
+    
+    event DailySupplyValidatorChanged(address oldValidator, address newValidator, uint256 timestamp);
     event BorrowerOperationsAddressToggled(address borrowerOperations, bool oldFlag, bool newFlag, uint256 timestamp);
     event TroveManagerToggled(address troveManager, bool oldFlag, bool newFlag, uint256 timestamp);
     event StabilityPoolToggled(address stabilityPool, bool oldFlag, bool newFlag, uint256 timestamp);
@@ -16,6 +17,7 @@ interface ILiquityLUSDToken is IERC20, IERC2612 {
     event LUSDTokenBalanceUpdated(address _user, uint _amount);
 
     // --- Functions ---
+    function setDailySupplyValidator(address validator) external;
 
     function toggleBorrowerOperations(address borrowerOperations) external;
 

--- a/packages/contracts/contracts/Interfaces/ISupplyValidator.sol
+++ b/packages/contracts/contracts/Interfaces/ISupplyValidator.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.0;
+
+interface ISupplyValidator {
+    function setDailyMintCap(uint256 newCap) external;
+    
+    function validateMintAndUpdate(uint256 amount) external;
+
+    function updateBurntSupply(uint256 amount) external;
+}

--- a/packages/contracts/contracts/TestContracts/EchidnaTester.sol
+++ b/packages/contracts/contracts/TestContracts/EchidnaTester.sol
@@ -121,7 +121,8 @@ contract EchidnaTester {
             address(defaultPool),
             address(collSurplusPool),
             address(0),
-            address(weth)
+            address(weth),
+            address(governance)
         );
 
         defaultPool.setAddresses(address(troveManager), address(activePool), address(weth));


### PR DESCRIPTION
- Add a daily supply validator, that will ensure that only a certain number of ARTH tokens are minter per day.

- Add the missing check for the `allowMinting` governance flag in the borrower operations whenever ARTH is minted.

- Add the missing check for `maxDebtCeiling` governance variable in the active pool contract whenever deb is increased.